### PR TITLE
fix an error when executing `docker build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.7.0
 
-RUN echo 'deb http://www.deb-multimedia.org stretch main non-free' >> /etc/apt/sources.list \
-      && echo 'deb-src http://www.deb-multimedia.org stretch main non-free' >> /etc/apt/sources.list \
+RUN echo 'deb http://www.deb-multimedia.org buster main non-free' >> /etc/apt/sources.list \
+      && echo 'deb-src http://www.deb-multimedia.org buster main non-free' >> /etc/apt/sources.list \
       && apt-key adv --keyserver pgp.mit.edu --recv-keys 5C808C2B65558117 \
       && apt-get -qq update \
       && apt-get -qq -y --allow-unauthenticated install deb-multimedia-keyring \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN echo 'deb http://www.deb-multimedia.org buster main non-free' >> /etc/apt/so
       && apt-get -qq -y --allow-unauthenticated install deb-multimedia-keyring \
       && apt-get -qq update \
       && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
-      && apt-get -qq -y install --no-install-recommends build-essential libmp3lame-dev libvorbis-dev libtheora-dev libspeex-dev yasm pkg-config libfaac-dev libopenjp2-7-dev libx264-dev ffmpeg libimlib2-dev libcurl4-openssl-dev default-libmysqlclient-dev libmagick++-dev libimage-exiftool-perl zip deb-multimedia-keyring mysql-client nodejs \
+      && apt-get -qq -y install --no-install-recommends build-essential libmp3lame-dev libvorbis-dev libtheora-dev libspeex-dev yasm pkg-config libfaac-dev libopenjp2-7-dev libx264-dev ffmpeg libimlib2-dev libcurl4-openssl-dev default-libmysqlclient-dev libmagick++-dev libimage-exiftool-perl zip deb-multimedia-keyring default-mysql-client nodejs \
       && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:2.7.0
 
 RUN echo 'deb http://www.deb-multimedia.org stretch main non-free' >> /etc/apt/sources.list \
       && echo 'deb-src http://www.deb-multimedia.org stretch main non-free' >> /etc/apt/sources.list \
+      && apt-key adv --keyserver pgp.mit.edu --recv-keys 5C808C2B65558117 \
       && apt-get -qq update \
       && apt-get -qq -y --allow-unauthenticated install deb-multimedia-keyring \
       && apt-get -qq update \


### PR DESCRIPTION
Hi @hfm 

I fixed an error when executing `docker build`.
ref：[Update Ruby to version 2\.7\.0 by rsym · Pull Request \#2 · hfm/docker\-ruby\-with\-multimedia](https://github.com/hfm/docker-ruby-with-multimedia/pull/2#issuecomment-575531474)

I confirmed that `docker build` and `docker run` are executed successfully.
Please review.


#### docker build

```
 ❯ docker build -t ruby-with-multimedia:2.7.0 .                                                                         [18:46:49]
Sending build context to Docker daemon  119.8kB
Step 1/2 : FROM ruby:2.7.0
 ---> fb53c5f433da
...
Removing intermediate container 5481e9efffa2
 ---> 87174a404acb
Successfully built 87174a404acb
Successfully tagged ruby-with-multimedia:2.7.0
```

```
 ❯ docker images ruby-with-multimedia:2.7.0                                                                             [18:48:34]
REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
ruby-with-multimedia   2.7.0               87174a404acb        15 seconds ago      1.13GB
```

#### docker run

```
 ❯ docker run -it --name ruby-with-multimedia ruby-with-multimedia:2.7.0                                                [18:51:41]
irb(main):001:1* def hello(name)
irb(main):002:1*   puts "Hello #{name}!"
irb(main):003:0> end
=> :hello
irb(main):004:0> hello('World')
Hello World!
=> nil
irb(main):005:0> exit
>>> elapsed time 46s
```
